### PR TITLE
fix(react): Fix React Hook useEffect missing dependencies

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/src/app/content/[id]/page.tsx
+++ b/src/app/content/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
@@ -65,22 +65,25 @@ export default function ContentDetail() {
   const [copied, setCopied] = useState<string | null>(null);
   const [showTranscript, setShowTranscript] = useState(false);
 
+  const fetchContent = useCallback(async () => {
+    const res = await fetch(`/api/content?contentId=${contentId}`);
+    const data = await res.json();
+    setContent(data.content);
+    setLoading(false);
+  }, [contentId]);
+
   useEffect(() => {
     fetchContent();
+  }, [fetchContent]);
+
+  useEffect(() => {
     const interval = setInterval(() => {
       if (content?.status === 'processing' || content?.status === 'pending') {
         fetchContent();
       }
     }, 5000);
     return () => clearInterval(interval);
-  }, [contentId, content?.status]);
-
-  async function fetchContent() {
-    const res = await fetch(`/api/content?contentId=${contentId}`);
-    const data = await res.json();
-    setContent(data.content);
-    setLoading(false);
-  }
+  }, [content?.status, fetchContent]);
 
   function copyToClipboard(text: string, id: string) {
     navigator.clipboard.writeText(text);

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
@@ -50,9 +50,9 @@ export default function Dashboard() {
   useEffect(() => {
     fetchUser();
     fetchContents();
-  }, []);
+  }, [fetchUser, fetchContents]);
 
-  async function fetchUser() {
+  const fetchUser = useCallback(async () => {
     const res = await fetch('/api/auth');
     const data = await res.json();
     if (!data.user) {
@@ -60,14 +60,14 @@ export default function Dashboard() {
       return;
     }
     setUser(data.user);
-  }
+  }, [router]);
 
-  async function fetchContents() {
+  const fetchContents = useCallback(async () => {
     const res = await fetch('/api/content');
     const data = await res.json();
     setContents(data.contents || []);
     setLoading(false);
-  }
+  }, []);
 
   async function handleYoutubeSubmit(e: React.FormEvent) {
     e.preventDefault();


### PR DESCRIPTION
## What

Fix react-hooks/exhaustive-deps warnings in dashboard and content detail pages.

## Changes

- Add useCallback import to dashboard/page.tsx and content/[id]/page.tsx
- Wrap fetchUser and fetchContents in useCallback with proper dependencies
- Wrap fetchContent in useCallback with contentId dependency
- Refactor useEffect hooks to include all required dependencies
- Split polling effect into separate useEffect in content/[id]/page.tsx for proper dependency management

## Tests

- [x] ESLint react-hooks/exhaustive-deps warnings resolved

Closes #11

---
Auto-created by overnight-dev-agent. Review before merging.