### PR TITLE
chore(tsconfig): add DOM types to TypeScript configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "target": "ES2020",
     "lib": [
-      "ES2020"
+      "ES2020",
+      "dom"
     ],
     "jsx": "preserve",
     "strict": true,


### PR DESCRIPTION
## What

Added "dom" to the TypeScript lib array in tsconfig.json. This fixes multiple type errors in client-side components that use DOM types like File, navigator, HTMLInputElement, etc.

## Changes
- Added "dom" to lib array in tsconfig.json

## Tests
- [x] Existing tests pass
- [x] No DOM-related type errors after change
- [x] Linter clean

Closes #21

---
_Auto-created by overnight-dev-agent. Review before merging._