### PR TITLE
refactor(api): extract helper functions from long POST handler

### DIFF
--- a/src/app/api/content/route.ts
+++ b/src/app/api/content/route.ts
@@ -10,6 +10,18 @@ import { uploadFile, generateFileKey } from '@/lib/storage';
 // Maximum file size: 100MB
 const MAX_FILE_SIZE = 100 * 1024 * 1024;
 
+interface FileUploadResult {
+  sourceType: string;
+  sourceFile: string;
+  title: string;
+}
+
+interface YouTubeSubmissionResult {
+  sourceType: string;
+  sourceUrl: string;
+  title: string;
+}
+
 /**
  * Validate file by reading magic bytes (not just extension)
  */
@@ -19,7 +31,7 @@ async function validateFileType(buffer: Buffer): Promise<{ valid: boolean; sourc
     if (!detectedType) {
       return { valid: false };
     }
-    
+
     const mimeToSourceType: Record<string, string> = {
       'audio/mpeg': 'audio',
       'audio/mp3': 'audio',
@@ -36,11 +48,168 @@ async function validateFileType(buffer: Buffer): Promise<{ valid: boolean; sourc
     if (!sourceType) {
       return { valid: false };
     }
-    
+
     return { valid: true, sourceType, mime: detectedType.mime };
   } catch {
     return { valid: false };
   }
+}
+
+/**
+ * Process file upload from multipart form data
+ */
+async function processFileUpload(
+  formData: FormData,
+  userId: string
+): Promise<FileUploadResult | NextResponse> {
+  const rawSourceType = formData.get('sourceType') as string;
+  const file = formData.get('file');
+
+  // Validate source type
+  if (!rawSourceType || !['audio', 'video', 'pdf'].includes(rawSourceType)) {
+    return NextResponse.json(
+      { error: 'Valid source type required (audio, video, pdf)' },
+      { status: 400 }
+    );
+  }
+
+  if (!file) {
+    return NextResponse.json(
+      { error: 'File upload required' },
+      { status: 400 }
+    );
+  }
+
+  // Check file size (file must be a File object)
+  if (typeof file !== 'object' || file === null || !('size' in file)) {
+    return NextResponse.json(
+      { error: 'Invalid file upload' },
+      { status: 400 }
+    );
+  }
+
+  const fileObj = file as { size: number; name: string; arrayBuffer: () => Promise<ArrayBuffer> };
+  if (fileObj.size > MAX_FILE_SIZE) {
+    return NextResponse.json(
+      { error: 'File too large. Maximum size is 100MB.' },
+      { status: 400 }
+    );
+  }
+
+  // Read file and validate type by magic bytes
+  const bytes = await fileObj.arrayBuffer();
+  const buffer = Buffer.from(bytes);
+
+  const typeValidation = await validateFileType(buffer);
+  if (!typeValidation.valid || typeValidation.sourceType !== rawSourceType) {
+    return NextResponse.json(
+      { error: `Invalid file type. Expected ${rawSourceType}, but file content doesn't match.` },
+      { status: 400 }
+    );
+  }
+
+  // Upload to S3
+  try {
+    const s3Key = generateFileKey(userId, rawSourceType, fileObj.name);
+    await uploadFile(s3Key, buffer, typeValidation.mime || 'application/octet-stream');
+
+    return {
+      sourceType: rawSourceType,
+      sourceFile: s3Key,
+      title: fileObj.name.replace(/\.[^/.]+$/, ''), // Remove extension
+    };
+  } catch (s3Error) {
+    console.error('S3 upload failed:', s3Error);
+
+    // Check if S3 is configured
+    if (!config.awsAccessKeyId || !config.awsSecretAccessKey) {
+      return NextResponse.json(
+        { error: 'File storage not configured. Set AWS credentials or use YouTube URLs for now.' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json(
+      { error: 'Failed to upload file. Please try again.' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * Process YouTube URL submission
+ */
+async function processYouTubeSubmission(
+  body: unknown
+): Promise<YouTubeSubmissionResult | NextResponse> {
+  // Validate input
+  const validated = createContentJsonSchema.safeParse(body);
+  if (!validated.success) {
+    return NextResponse.json(
+      { error: 'Invalid input', details: validated.error.errors },
+      { status: 400 }
+    );
+  }
+
+  const { sourceType, sourceUrl } = validated.data;
+
+  if (sourceType === 'youtube') {
+    if (!sourceUrl) {
+      return NextResponse.json(
+        { error: 'YouTube URL required' },
+        { status: 400 }
+      );
+    }
+
+    // Validate YouTube URL and extract video ID
+    const videoId = validateVideoId(sourceUrl);
+    if (!videoId) {
+      return NextResponse.json(
+        { error: 'Invalid YouTube URL' },
+        { status: 400 }
+      );
+    }
+
+    // Get video title
+    try {
+      const videoInfo = await getVideoInfo(sourceUrl);
+      return {
+        sourceType,
+        sourceUrl,
+        title: videoInfo.title,
+      };
+    } catch (e) {
+      console.error('Failed to fetch video info:', e);
+      return NextResponse.json(
+        { error: 'Failed to fetch video info. Please check URL.' },
+        { status: 400 }
+      );
+    }
+  } else if (!sourceUrl) {
+    return NextResponse.json(
+      { error: 'Source URL required' },
+      { status: 400 }
+    );
+  }
+
+  return {
+    sourceType,
+    sourceUrl,
+    title: 'Untitled',
+  };
+}
+
+/**
+ * Trigger background content generation
+ */
+function triggerContentGeneration(contentId: string, request: NextRequest): void {
+  fetch(`${config.appUrl}/api/content/${contentId}/generate`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Cookie': request.headers.get('cookie') || '',
+    },
+  }).catch(err => console.error('Background generation failed:', err));
 }
 
 export async function POST(request: NextRequest) {
@@ -51,7 +220,7 @@ export async function POST(request: NextRequest) {
     }
 
     const contentType = request.headers.get('content-type') || '';
-    
+
     let sourceType: string;
     let sourceUrl: string | undefined;
     let sourceFile: string | undefined;
@@ -60,61 +229,16 @@ export async function POST(request: NextRequest) {
     // Handle FormData (file upload)
     if (contentType.includes('multipart/form-data')) {
       const formData = await request.formData();
-      const rawSourceType = formData.get('sourceType') as string;
-      const file = formData.get('file');
-      
-      // Validate source type
-      if (!rawSourceType || !['audio', 'video', 'pdf'].includes(rawSourceType)) {
-        return NextResponse.json({ error: 'Valid source type required (audio, video, pdf)' }, { status: 400 });
+      const fileResult = await processFileUpload(formData, userId);
+
+      if (fileResult instanceof NextResponse) {
+        return fileResult; // Return error response
       }
 
-      if (!file) {
-        return NextResponse.json({ error: 'File upload required' }, { status: 400 });
-      }
-
-      // Check file size (file must be a File object)
-      if (typeof file !== 'object' || file === null || !('size' in file)) {
-        return NextResponse.json({ error: 'Invalid file upload' }, { status: 400 });
-      }
-
-      const fileObj = file as { size: number; name: string; arrayBuffer: () => Promise<ArrayBuffer> };
-      if (fileObj.size > MAX_FILE_SIZE) {
-        return NextResponse.json({ error: 'File too large. Maximum size is 100MB.' }, { status: 400 });
-      }
-
-      // Read file and validate type by magic bytes
-      const bytes = await fileObj.arrayBuffer();
-      const buffer = Buffer.from(bytes);
-
-      const typeValidation = await validateFileType(buffer);
-      if (!typeValidation.valid || typeValidation.sourceType !== rawSourceType) {
-        return NextResponse.json({ 
-          error: `Invalid file type. Expected ${rawSourceType}, but file content doesn't match.` 
-        }, { status: 400 });
-      }
-
-      // Upload to S3 instead of local filesystem (required for Railway)
-      try {
-        const s3Key = generateFileKey(userId, rawSourceType, fileObj.name);
-        await uploadFile(s3Key, buffer, typeValidation.mime || 'application/octet-stream');
-        sourceFile = s3Key;
-        sourceType = rawSourceType;
-        title = fileObj.name.replace(/\.[^/.]+$/, ''); // Remove extension
-      } catch (s3Error) {
-        console.error('S3 upload failed:', s3Error);
-        
-        // Check if S3 is configured
-        if (!config.awsAccessKeyId || !config.awsSecretAccessKey) {
-          return NextResponse.json({ 
-            error: 'File storage not configured. Set AWS credentials or use YouTube URLs for now.' 
-          }, { status: 500 });
-        }
-        
-        return NextResponse.json({ 
-          error: 'Failed to upload file. Please try again.' 
-        }, { status: 500 });
-      }
-    } 
+      sourceType = fileResult.sourceType;
+      sourceFile = fileResult.sourceFile;
+      title = fileResult.title;
+    }
     // Handle JSON (YouTube URL)
     else {
       let body;
@@ -124,37 +248,15 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
       }
 
-      // Validate input
-      const validated = createContentJsonSchema.safeParse(body);
-      if (!validated.success) {
-        return NextResponse.json({ error: 'Invalid input', details: validated.error.errors }, { status: 400 });
+      const youtubeResult = await processYouTubeSubmission(body);
+
+      if (youtubeResult instanceof NextResponse) {
+        return youtubeResult; // Return error response
       }
 
-      sourceType = validated.data.sourceType;
-      sourceUrl = validated.data.sourceUrl;
-
-      if (sourceType === 'youtube') {
-        if (!sourceUrl) {
-          return NextResponse.json({ error: 'YouTube URL required' }, { status: 400 });
-        }
-
-        // Validate YouTube URL and extract video ID
-        const videoId = validateVideoId(sourceUrl);
-        if (!videoId) {
-          return NextResponse.json({ error: 'Invalid YouTube URL' }, { status: 400 });
-        }
-
-        // Get video title for YouTube
-        try {
-          const videoInfo = await getVideoInfo(sourceUrl);
-          title = videoInfo.title;
-        } catch (e) {
-          console.error('Failed to fetch video info:', e);
-          return NextResponse.json({ error: 'Failed to fetch video info. Please check the URL.' }, { status: 400 });
-        }
-      } else if (!sourceUrl) {
-        return NextResponse.json({ error: 'Source URL required' }, { status: 400 });
-      }
+      sourceType = youtubeResult.sourceType;
+      sourceUrl = youtubeResult.sourceUrl;
+      title = youtubeResult.title;
     }
 
     // Create content record
@@ -169,16 +271,8 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    // For demo: Auto-generate mock outputs asynchronously
-    const contentId = content.id;
-    
-    fetch(`${config.appUrl}/api/content/${contentId}/generate`, {
-      method: 'POST',
-      headers: { 
-        'Content-Type': 'application/json',
-        'Cookie': request.headers.get('cookie') || '',
-      },
-    }).catch(err => console.error('Background generation failed:', err));
+    // Trigger background generation
+    triggerContentGeneration(content.id, request);
 
     return NextResponse.json({
       success: true,
@@ -208,7 +302,7 @@ export async function GET(request: NextRequest) {
       // Get single content with outputs - MUST verify ownership
       const content = await prisma.content.findFirst({
         where: { id: contentId, userId }, // Enforce ownership
-        include: { 
+        include: {
           outputs: true,
           _count: { select: { outputs: true } }
         },


### PR DESCRIPTION
## What

Refactored the POST handler in src/app/api/content/route.ts by extracting helper functions. The main POST function was 145 lines and has been reduced to 73 lines.

## Changes
- Extracted `processFileUpload()` helper (~70 lines) - handles multipart form data and file processing
- Extracted `processYouTubeSubmission()` helper (~70 lines) - handles YouTube URL processing
- Extracted `triggerContentGeneration()` helper (~10 lines) - handles async generation trigger
- POST function now uses these helpers, making it more readable and maintainable
- Each helper can be unit tested independently

## Tests
- [x] Existing tests pass
- [x] Linter clean
- [x] Function complexity reduced (145 → 73 lines)

Closes #19

---
_Auto-created by overnight-dev-agent. Review before merging._